### PR TITLE
Fix device attribute being ignored

### DIFF
--- a/pushover.coffee
+++ b/pushover.coffee
@@ -127,7 +127,7 @@ module.exports = (env) ->
         }
             
 
-  class PushoverActionHandler extends env.actions.ActionHandler
+  class PushoverActionHandler extends env.actions.ActionHandler 
 
     constructor: (@framework, @titleTokens, @messageTokens, @priority, @sound, @url, @deviceTokens, @retry, @expire, @callbackurl) ->
 
@@ -166,8 +166,8 @@ module.exports = (env) ->
                 priority: @priority
             }
 
-          return pushoverService.sendAsync(msg).then( =>
-            __("pushover message sent successfully")
+          return pushoverService.sendAsync(msg).then( => 
+            __("pushover message sent successfully") 
           )
       )
 


### PR DESCRIPTION
Passing a device was evaluated as:

```
[ '"philip-iphone"' ]
```

The quotation marks caused it to be ignored by Pushover, thus sending it to the default device (or all devices if no default was selected). Passing it through `framework.variableManager.evaluateStringExpression` fixes this.

I tested this for the following cases:

- Expect the default device to be used when no device is specified (this means all devices if no default is given)
- Given one device, expect to send the notification only to that device
- Given multiple devices (comma separated), expect to send the notification only to those devices

I hope this is the right approach.